### PR TITLE
feat: PAAL-175 add agentCard rewrite plugin

### DIFF
--- a/test/e2e/agentgateway_e2e_test.go
+++ b/test/e2e/agentgateway_e2e_test.go
@@ -18,6 +18,7 @@ package e2e
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os/exec"
 	"time"
@@ -30,6 +31,8 @@ import (
 
 var _ = Describe("Agent Gateway", Ordered, func() {
 
+	var gatewayUrl string
+
 	// After each test, check for failures and collect logs, events,
 	// and pod descriptions for debugging.
 	AfterEach(func() {
@@ -40,16 +43,7 @@ var _ = Describe("Agent Gateway", Ordered, func() {
 		}
 	})
 
-	AfterEach(func() {
-		By("cleaning up test resources")
-		_, _ = utils.Run(exec.Command("kubectl", "delete", "agent",
-			"-f", "config/samples/runtime_v1alpha1_agent.yaml"))
-
-		_, _ = utils.Run(exec.Command("kubectl", "delete", "agent",
-			"-f", "config/samples/runtime_v1alpha1_agentgateway.yaml"))
-	})
-
-	It("should proxy A2A requests to agent", func() {
+	BeforeAll(func() {
 		// TODO: Once the agent gateway correctly updates itself upon agent changes, join agent and gateway
 		// into one file.
 		By("applying the agent")
@@ -73,9 +67,23 @@ var _ = Describe("Agent Gateway", Ordered, func() {
 
 		By("creating port-forward to the gateway")
 		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		DeferCleanup(cancel)
 		localPort, err := utils.PortForwardService(ctx, "default", "agent-gateway", 10000)
 		Expect(err).NotTo(HaveOccurred(), "Failed to create port-forward to agent gateway")
+
+		gatewayUrl = fmt.Sprintf("http://localhost:%d", localPort)
+	})
+
+	AfterAll(func() {
+		By("cleaning up test resources")
+		_, _ = utils.Run(exec.Command("kubectl", "delete", "agent",
+			"-f", "config/samples/runtime_v1alpha1_agent.yaml"))
+
+		_, _ = utils.Run(exec.Command("kubectl", "delete", "agent",
+			"-f", "config/samples/runtime_v1alpha1_agentgateway.yaml"))
+	})
+
+	It("should proxy A2A requests to agent", func() {
 
 		By("sending HTTP request to the gateway")
 		payload := map[string]interface{}{
@@ -97,8 +105,23 @@ var _ = Describe("Agent Gateway", Ordered, func() {
 				"metadata": map[string]interface{}{},
 			},
 		}
-		url := fmt.Sprintf("http://localhost:%d/mocked-agent-exposed-1/", localPort)
-		err = utils.PostRequest(url, payload)
+		body, err := utils.PostRequest(gatewayUrl+"/mocked-agent-exposed-1", payload)
 		Expect(err).NotTo(HaveOccurred(), "Failed to send POST request to agent gateway")
+
+		var responseMap map[string]interface{}
+		err = json.Unmarshal(body, &responseMap)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(responseMap["result"]).NotTo(BeNil())
+	})
+
+	It("should retrieve agent card with correct url", func() {
+		By("retrieving agent card from the gateway")
+		body, err := utils.GetRequest(gatewayUrl + "/mocked-agent-exposed-1/.well-known/agent-card.json")
+		Expect(err).NotTo(HaveOccurred(), "Failed to send GET request to agent-card endpoint")
+
+		var responseMap map[string]interface{}
+		err = json.Unmarshal(body, &responseMap)
+		Expect(err).NotTo(HaveOccurred(), "Failed to unmarshal agent card response")
+		Expect(responseMap["url"]).To(Equal(gatewayUrl + "/mocked-agent-exposed-1"))
 	})
 })

--- a/test/utils/http.go
+++ b/test/utils/http.go
@@ -10,22 +10,36 @@ import (
 )
 
 // PostRequest sends a POST request with a JSON payload to the specified URL
-func PostRequest(url string, payload any) error {
+func PostRequest(url string, payload any) ([]byte, error) {
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
-		return fmt.Errorf("failed to marshal payload: %w", err)
+		return nil, fmt.Errorf("failed to marshal payload: %w", err)
 	}
 
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(payloadBytes))
 	if err != nil {
-		return err
+		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
 
+	return request(req)
+}
+
+// GetRequest sends a GET request to the specified URL and returns the response body
+func GetRequest(url string) ([]byte, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return request(req)
+}
+
+func request(req *http.Request) ([]byte, error) {
 	client := &http.Client{Timeout: 10 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("HTTP request failed: %w", err)
+		return nil, fmt.Errorf("HTTP request failed: %w", err)
 	}
 	defer func(Body io.ReadCloser) {
 		err := Body.Close()
@@ -34,10 +48,9 @@ func PostRequest(url string, payload any) error {
 		}
 	}(resp.Body)
 
+	bodyBytes, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {
-		bodyBytes, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("expected HTTP 200 status code, got: %d, body: %s", resp.StatusCode, string(bodyBytes))
+		return nil, fmt.Errorf("expected HTTP 200 status code, got: %d, body: %s", resp.StatusCode, string(bodyBytes))
 	}
-
-	return nil
+	return bodyBytes, nil
 }


### PR DESCRIPTION
### Added e2e tests

* **Test 1: should route agent card endpoint requests correctly**
    * **Purpose:** Validates basic agent card endpoint routing works
    * **Agent Type:** A2A (no path)
    * **Key Validations:**
        * HTTP 200 response
        * Routing to `/.well-known/agent-card.json`
        * Valid JSON response
        * Agent name and description present

* **Test 2: should return properly formatted agent card data**
    * **Purpose:** Validates complete agent card schema with all required fields
    * **Agent Type:** A2A (no path)
    * **Key Validations:**
        * HTTP 200 response
        * Required schema fields: name, description, version
        * Capabilities array
        * Protocols object
        * Metadata object
        * Endpoints array

* **Test 3: should create ConfigMap with correct plugin configuration**
    * **Purpose:** Validates KrakenD plugin configuration and correct ordering
    * **Agent Type:** A2A (no path)
    * **Key Validations:**
        * ConfigMap exists
        * JSON contains `plugin_names`
        * Array has 2 plugins
        * Order: `["agentcard-rw", "openai-a2a"]`
        * Correct plugin order (matters per code comment)

* **Test 4: should route agent card requests for agents with protocol paths**
    * **Purpose:** Validates agent card endpoints work with non-empty protocol paths
    * **Agent Type:** A2A with path `/api/v1`
    * **Key Validations:**
        * HTTP 200 response
        * Routing to `/agent/api/v1/.well-known/agent-card.json`
        * Valid JSON with path info
        * Protocol endpoint path present

* **Test 5: should create agent card endpoint for OpenAI-only agents**
    * **Purpose:** Validates OpenAI agents get agent cards (A2A-compatible via plugin)
    * **Agent Type:** OpenAI with path `/v1`
    * **Key Validations:**
        * HTTP 200 response
        * Routing to `/agent/v1/.well-known/agent-card.json`
        * Valid OpenAI agent card JSON
        * ConfigMap has 2 endpoints (agent card + OpenAI)
        * Chat-completion capabilities

---

Related PR: https://github.com/agentic-layer/agent-gateway-krakend/pull/10